### PR TITLE
Re-Add kahoot command with global bot limit

### DIFF
--- a/src/main/java/Commands/KahootCommand.java
+++ b/src/main/java/Commands/KahootCommand.java
@@ -1,0 +1,88 @@
+package Commands;
+
+import de.btobastian.sdcf4j.Command;
+import de.btobastian.sdcf4j.CommandExecutor;
+
+import java.io.IOException;
+
+public class KahootCommand implements CommandExecutor {
+
+   // private KahootHack kahootHackAPI = new KahootHack();
+    private static Integer maxBots = 50;
+    private static Integer currentBots = 0;
+
+    @Command(aliases = {"kahoot"}, description = "Deploys up to 50 bots to *hack* kahoot", usage = "kahoot [game pin] [bot name] [number of bots]")
+    public static String onKahootCommand(String[] args) throws IOException {
+        if (args.length == 3) {
+            if (isInteger(args[0])) {
+                int pin = Integer.parseInt(args[0]);
+                //TODO: Might want to check if pin is an actual game here...
+                if (pin >= 1000000 && pin <= 9999999) {
+                    if (isInteger(args[2])) {
+
+
+                        int botsToAdd = Integer.parseInt(args[2]);
+                        String botName = args[1];
+
+                        if (botsToAdd + currentBots > maxBots) {
+
+                            currentBots = currentBots + botsToAdd;
+
+                            //spawn in the bots here
+
+                            return "Check kahoot!";
+
+
+                        } else {
+                            return "Too many bots! There is a maximum of " + maxBots + " bots running at once. Please wait until a kahoot game has ended or decrease the number of bots you are adding.";
+                        }
+                    }
+                }
+            } else {
+                return "Invalid Pin!";
+            }
+        }
+        else {
+            return "Wrong arguments! Check usage with `~help`";
+        }
+        return "Something went wrong. Please try again";
+    }
+
+    private static boolean isInteger(String str) {
+        if (str == null) {
+            return false;
+        }
+        int length = str.length();
+        if (length == 0) {
+            return false;
+        }
+        int i = 0;
+        if (str.charAt(0) == '-') {
+            if (length == 1) {
+                return false;
+            }
+            i = 1;
+        }
+        for (; i < length; i++) {
+            char c = str.charAt(i);
+            if (c < '0' || c > '9') {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public static void removeBot(){
+        removeBots(1);
+    }
+
+    public static void removeBots(int botsToRemove){
+        if (currentBots - botsToRemove >= 0) {
+
+        } else {
+            System.out.println("ERROR: Not enough bots to remove!");
+        }
+
+    }
+
+}

--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -1,5 +1,6 @@
 import Commands.HelpCommand;
 import Commands.JokeCommand;
+import Commands.KahootCommand;
 import Commands.PastaCommand;
 import de.btobastian.sdcf4j.CommandHandler;
 import de.btobastian.sdcf4j.handler.Discord4JHandler;
@@ -20,6 +21,7 @@ public class Main {
         handler.setDefaultPrefix("~");
         handler.registerCommand(new PastaCommand());
         handler.registerCommand(new JokeCommand());
+        handler.registerCommand(new KahootCommand());
         handler.registerCommand(new HelpCommand(handler));
     }
 }


### PR DESCRIPTION
This pull request is an incomplete feature.

TODO:

- [ ] Find some code (preferably java) to create the bots
- [ ] Have bot hack code call `removeBot()` or `removeBots()` to decrement the counter when each bot or batch of bots "expires" (i.e. the kahoot game ends and they are disconnected/no longer needed and the resources are freed for the next bot)